### PR TITLE
Refactor Ride the Horizon logic with automated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
-# codex-biking-game
+# Ride the Horizon
+
+A meditative watercolor biking experience built with HTML5 canvas. Ride endlessly through shifting biomes, collect gentle memories, and let ambience react to your pace.
+
+## Play
+
+Open [`index.html`](./index.html) in any modern browser or host the repository with a static server. The project is designed to deploy directly to GitHub Pages.
+
+## Controls
+
+- **Hold Space** – pedal forward.
+- **← / A** – lean toward a calmer, slower cadence.
+- **→ / D** – lean into swifter motion.
+- **Enable sound** – click the button in the lower panel to fade in ambient wind.
+
+Slow down near glimmering glyphs to uncover memory fragments tied to each biome.
+
+## Development
+
+The project is entirely client-side. You can use any static server for local development:
+
+```bash
+npx serve .
+```
+
+Or use Python:
+
+```bash
+python -m http.server
+```
+
+Then open your browser at the served address.
+
+### Testing
+
+The logic that powers biome transitions and memory fragments is covered by unit tests. Run them with the built-in Node test runner:
+
+```bash
+npm test
+```
+
+## Deployment
+
+Because the repository is static, enable GitHub Pages in the repository settings and point it to the `main` branch (or `docs` branch if you prefer). The entry point is `index.html` at the repository root.
+
+## Accessibility
+
+- Responsive layout and font scaling for mobile screens.
+- Canvas is labelled for screen reader context.
+- Instructions remain visible while playing.
+- Memories fade gently to avoid clutter while preserving a written log.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ride the Horizon</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="app">
+      <canvas id="horizon-canvas" aria-label="Ride the Horizon watercolor landscape"></canvas>
+      <section class="overlay" aria-live="polite">
+        <header class="overlay__header">
+          <h1>Ride the Horizon</h1>
+          <p>Hold <kbd>space</kbd> to pedal. Use <kbd>&larr;</kbd> and <kbd>&rarr;</kbd> to lean between calm and swift moods. Pause and listen when the world calls.</p>
+        </header>
+        <div class="overlay__memories" id="memories"></div>
+        <footer class="overlay__footer">
+          <button id="toggle-sound" type="button" aria-pressed="false">Enable sound</button>
+        </footer>
+      </section>
+    </main>
+    <script type="module" src="js/ride-the-horizon.js"></script>
+  </body>
+</html>

--- a/js/game-core.js
+++ b/js/game-core.js
@@ -1,0 +1,206 @@
+export const biomes = [
+  {
+    name: "Aurora Fields",
+    sky: ["#f4ede4", "#f7d9d4", "#c5e3f6"],
+    horizon: ["#d7c0ae", "#9ad0ec"],
+    accents: ["#ffb5a7", "#84a59d", "#f6bd60"],
+    memory: "A paper crane drifted beside you for miles.",
+  },
+  {
+    name: "Opal Forest",
+    sky: ["#fef6fb", "#e3f2f1", "#d0e6a5"],
+    horizon: ["#91c4c4", "#c4d7b2"],
+    accents: ["#adf7b6", "#ffcbf2", "#cddafd"],
+    memory: "You hummed a forgotten lullaby and the trees harmonised.",
+  },
+  {
+    name: "Solstice Coast",
+    sky: ["#fce7c3", "#f8d8be", "#d9f1ff"],
+    horizon: ["#f7a9a8", "#8ecae6"],
+    accents: ["#ffafcc", "#cdb4db", "#a2d2ff"],
+    memory: "Tidal bells rang softly from a sunken tower.",
+  },
+  {
+    name: "Celestial Steppe",
+    sky: ["#f7f0ff", "#d2d0fe", "#c0e8f9"],
+    horizon: ["#cdb4db", "#bde0fe"],
+    accents: ["#ffc8dd", "#a0c4ff", "#b9fbc0"],
+    memory: "Constellations rearranged to mirror your heartbeat.",
+  },
+];
+
+export const memoryLibrary = [
+  "A quiet laugh echoed through the grasses.",
+  "Someone waved from a hill made of folded letters.",
+  "Rain painted silver ripples across the path.",
+  "You rode past a river of lanterns that never went out.",
+  "The wind carried a promise to return someday.",
+  "Petals followed, spelling your name in cursive arcs.",
+  "An old friend left a lantern at the crossroads.",
+  "Clouds opened like pages in a storybook.",
+];
+
+export const biomeLength = 2800;
+
+export function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+
+export function easeInOut(t) {
+  const clamped = Math.max(0, Math.min(1, t));
+  return clamped < 0.5
+    ? 2 * clamped * clamped
+    : -1 + (4 - 2 * clamped) * clamped;
+}
+
+export function normaliseProgress(progress, total) {
+  if (!Number.isFinite(progress)) {
+    throw new TypeError("Progress must be a finite number");
+  }
+  const wrapped = ((progress % total) + total) % total;
+  const index = Math.floor(wrapped);
+  return { index, blend: wrapped - index };
+}
+
+export function getBiome(progress, list = biomes) {
+  if (!Array.isArray(list) || list.length === 0) {
+    throw new Error("Biome list must contain at least one biome");
+  }
+  const { index, blend } = normaliseProgress(progress, list.length);
+  const next = (index + 1) % list.length;
+  return { current: list[index], next: list[next], blend };
+}
+
+export class ColorCache {
+  constructor(parser = parseColor) {
+    this.parser = parser;
+    this.cache = new Map();
+  }
+
+  get(color) {
+    if (!this.cache.has(color)) {
+      this.cache.set(color, this.parser(color));
+    }
+    return this.cache.get(color);
+  }
+}
+
+export function parseHexColor(hex) {
+  let value = hex.slice(1);
+  if (![3, 6].includes(value.length)) {
+    throw new Error(`Unsupported hex color: ${hex}`);
+  }
+  if (value.length === 3) {
+    value = value
+      .split("")
+      .map((char) => char + char)
+      .join("");
+  }
+  const int = Number.parseInt(value, 16);
+  return {
+    r: (int >> 16) & 255,
+    g: (int >> 8) & 255,
+    b: int & 255,
+  };
+}
+
+export function parseRgbColor(color) {
+  const match = color
+    .replace(/rgba?\(/, "")
+    .replace(/\)/, "")
+    .split(",")
+    .map((component) => Number.parseFloat(component.trim()));
+  if (match.length < 3 || match.some((value) => Number.isNaN(value))) {
+    throw new Error(`Unsupported rgb color: ${color}`);
+  }
+  return { r: match[0], g: match[1], b: match[2] };
+}
+
+export function parseColor(color) {
+  if (typeof color !== "string" || color.length === 0) {
+    throw new TypeError("Color must be a non-empty string");
+  }
+  if (color.startsWith("#")) {
+    return parseHexColor(color);
+  }
+  if (color.startsWith("rgb")) {
+    return parseRgbColor(color);
+  }
+
+  if (typeof document === "undefined" || typeof getComputedStyle === "undefined") {
+    throw new Error("Named color parsing requires a DOM environment");
+  }
+
+  const temp = document.createElement("span");
+  temp.style.color = color;
+  document.body.appendChild(temp);
+  const computed = getComputedStyle(temp).color;
+  temp.remove();
+  return parseColor(computed);
+}
+
+export function lerpColor(colorA, colorB, t, cache) {
+  const colourCache = cache ?? new ColorCache();
+  const a = colourCache.get(colorA);
+  const b = colourCache.get(colorB);
+  return `rgb(${Math.round(lerp(a.r, b.r, t))}, ${Math.round(lerp(a.g, b.g, t))}, ${Math.round(
+    lerp(a.b, b.b, t)
+  )})`;
+}
+
+export function gradientColor(colors, t, cache) {
+  if (!Array.isArray(colors) || colors.length === 0) {
+    throw new Error("Gradient requires at least one color");
+  }
+  if (colors.length === 1) {
+    return colors[0];
+  }
+  const clamped = Math.max(0, Math.min(1, t));
+  const scaled = clamped * (colors.length - 1);
+  const index = Math.floor(scaled);
+  const blend = scaled - index;
+  const colourCache = cache ?? new ColorCache();
+  const a = colourCache.get(colors[index]);
+  const b = colourCache.get(colors[Math.min(colors.length - 1, index + 1)]);
+  return `rgb(${Math.round(lerp(a.r, b.r, blend))}, ${Math.round(lerp(a.g, b.g, blend))}, ${Math.round(
+    lerp(a.b, b.b, blend)
+  )})`;
+}
+
+export function createMemoryFragment(
+  distance,
+  {
+    rng = Math.random,
+    library = memoryLibrary,
+    biomeList = biomes,
+    length = biomeLength,
+  } = {}
+) {
+  if (!Number.isFinite(distance)) {
+    throw new TypeError("Distance must be a finite number");
+  }
+  if (typeof rng !== "function") {
+    throw new TypeError("rng must be a function");
+  }
+  if (!Array.isArray(library) || library.length === 0) {
+    throw new Error("Memory library must contain at least one entry");
+  }
+  if (!Array.isArray(biomeList) || biomeList.length === 0) {
+    throw new Error("Biome list must contain at least one biome");
+  }
+  if (!Number.isFinite(length) || length <= 0) {
+    throw new TypeError("Biome length must be a positive number");
+  }
+
+  const biomeIndex = Math.floor(distance / length) % biomeList.length;
+  const biome = biomeList[(biomeIndex + biomeList.length) % biomeList.length];
+  const textIndex = Math.floor(rng() * library.length) % library.length;
+  const idNonce = Math.max(rng(), Number.EPSILON).toString(16).slice(2);
+  return {
+    id: `${distance}-${idNonce}`,
+    biome: biome.name,
+    text: library[textIndex],
+    triggerAt: distance,
+    collected: false,
+  };
+}

--- a/js/ride-the-horizon.js
+++ b/js/ride-the-horizon.js
@@ -1,0 +1,419 @@
+import {
+  biomeLength,
+  lerp,
+  easeInOut,
+  getBiome,
+  gradientColor,
+  lerpColor,
+  ColorCache,
+  createMemoryFragment,
+} from "./game-core.js";
+
+const canvas = document.getElementById("horizon-canvas");
+const memoriesContainer = document.getElementById("memories");
+const toggleSoundButton = document.getElementById("toggle-sound");
+
+if (!canvas || !memoriesContainer || !toggleSoundButton) {
+  throw new Error("Ride the Horizon failed to initialise required DOM elements");
+}
+
+const ctx = canvas.getContext("2d", { alpha: true });
+if (!ctx) {
+  throw new Error("Unable to create 2D context for Ride the Horizon");
+}
+
+let width = 0;
+let height = 0;
+let pixelRatio = window.devicePixelRatio || 1;
+
+const pedals = {
+  pressed: false,
+  left: false,
+  right: false,
+};
+
+const settings = {
+  baseSpeed: 0.8,
+  boostSpeed: 3.6,
+  worldScroll: 0,
+  time: 0,
+};
+
+const colorCache = new ColorCache();
+
+const watercolorBrushes = Array.from({ length: 24 }, () => ({
+  x: Math.random(),
+  y: Math.random(),
+  radius: 40 + Math.random() * 160,
+  speed: 0.0005 + Math.random() * 0.0014,
+  hue: Math.random() * 360,
+  offset: Math.random() * Math.PI * 2,
+}));
+
+const parallaxLayers = [
+  { depth: 0.15, blobs: [] },
+  { depth: 0.3, blobs: [] },
+  { depth: 0.55, blobs: [] },
+];
+
+const memoryFragments = [];
+
+function updatePixelRatio() {
+  pixelRatio = window.devicePixelRatio || 1;
+}
+
+function resize() {
+  updatePixelRatio();
+  width = canvas.width = Math.floor(window.innerWidth * pixelRatio);
+  height = canvas.height = Math.floor(window.innerHeight * pixelRatio);
+  canvas.style.width = `${window.innerWidth}px`;
+  canvas.style.height = `${window.innerHeight}px`;
+  ctx.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0);
+  generateParallaxBlobs();
+}
+
+window.addEventListener("resize", resize);
+
+function generateParallaxBlobs() {
+  parallaxLayers.forEach((layer) => {
+    layer.blobs = Array.from({ length: 14 }, () => ({
+      x: Math.random() * (width / pixelRatio + 600),
+      y: Math.random() * (height / pixelRatio),
+      r: 80 + Math.random() * 220,
+      hueShift: (Math.random() - 0.5) * 50,
+      alpha: 0.08 + Math.random() * 0.08,
+    }));
+  });
+}
+
+const bike = {
+  x: 220,
+  y: () => height / pixelRatio - 140,
+  speed: 0,
+  targetSpeed: 0,
+  lean: 0,
+  wobble: 0,
+};
+
+class AmbientSound {
+  constructor() {
+    this.active = false;
+    this.context = null;
+    this.gain = null;
+    this.noise = null;
+    this.filter = null;
+  }
+
+  async toggle() {
+    if (this.active) {
+      this.stop();
+      return;
+    }
+    if (!this.context) {
+      this.context = new (window.AudioContext || window.webkitAudioContext)();
+      this.gain = this.context.createGain();
+      this.filter = this.context.createBiquadFilter();
+      this.filter.type = "lowpass";
+      this.filter.frequency.value = 1100;
+      this.gain.gain.value = 0.0001;
+      this.gain.connect(this.context.destination);
+      this.filter.connect(this.gain);
+      this.createNoise();
+    }
+    await this.context.resume();
+    this.active = true;
+    toggleSoundButton.textContent = "Disable sound";
+    toggleSoundButton.setAttribute("aria-pressed", "true");
+    this.fadeTo(0.18);
+  }
+
+  stop() {
+    if (!this.active) return;
+    this.active = false;
+    this.fadeTo(0.0001);
+    toggleSoundButton.textContent = "Enable sound";
+    toggleSoundButton.setAttribute("aria-pressed", "false");
+  }
+
+  fadeTo(value) {
+    if (!this.gain || !this.context) return;
+    const now = this.context.currentTime;
+    this.gain.gain.cancelScheduledValues(now);
+    this.gain.gain.exponentialRampToValueAtTime(Math.max(0.0001, value), now + 1.4);
+  }
+
+  createNoise() {
+    if (!this.context || !this.filter) return;
+    const bufferSize = 2 * this.context.sampleRate;
+    const buffer = this.context.createBuffer(1, bufferSize, this.context.sampleRate);
+    const data = buffer.getChannelData(0);
+    for (let i = 0; i < bufferSize; i += 1) {
+      data[i] = Math.random() * 2 - 1;
+    }
+    this.noise = this.context.createBufferSource();
+    this.noise.buffer = buffer;
+    this.noise.loop = true;
+    this.noise.connect(this.filter);
+    this.noise.start(0);
+  }
+
+  update(speedFactor) {
+    if (!this.active || !this.filter || !this.context) return;
+    const base = 600 + speedFactor * 1100;
+    this.filter.frequency.setTargetAtTime(base, this.context.currentTime, 0.4);
+  }
+}
+
+const ambientSound = new AmbientSound();
+
+toggleSoundButton.addEventListener("click", () => {
+  ambientSound.toggle();
+});
+
+function handleKey(e, pressed) {
+  if (e.repeat) return;
+  switch (e.code) {
+    case "Space":
+      pedals.pressed = pressed;
+      break;
+    case "ArrowLeft":
+    case "KeyA":
+      pedals.left = pressed;
+      break;
+    case "ArrowRight":
+    case "KeyD":
+      pedals.right = pressed;
+      break;
+    default:
+  }
+}
+
+document.addEventListener("keydown", (e) => handleKey(e, true));
+document.addEventListener("keyup", (e) => handleKey(e, false));
+
+function renderWatercolorBackdrop(progress) {
+  const { current, next, blend } = getBiome(progress);
+  const easing = easeInOut(blend);
+  const blendedSky = current.sky.map((color, index) =>
+    lerpColor(color, next.sky[index % next.sky.length], easing, colorCache)
+  );
+  const gradient = ctx.createLinearGradient(0, 0, 0, canvas.height / pixelRatio);
+  const stops = 6;
+  for (let i = 0; i < stops; i += 1) {
+    const t = i / (stops - 1);
+    const color = gradientColor(blendedSky, t, colorCache);
+    gradient.addColorStop(t, color);
+  }
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, canvas.width / pixelRatio, canvas.height / pixelRatio);
+}
+
+function drawParallax(progress) {
+  const { current, next, blend } = getBiome(progress);
+  const easing = easeInOut(blend);
+  parallaxLayers.forEach((layer, index) => {
+    const depth = layer.depth;
+    ctx.save();
+    ctx.globalAlpha = 0.8 - depth * 0.8;
+    const baseColor = lerpColor(
+      current.horizon[index % current.horizon.length],
+      next.horizon[index % next.horizon.length],
+      easing,
+      colorCache
+    );
+    layer.blobs.forEach((blob) => {
+      const offset = (settings.worldScroll * depth) % (width / pixelRatio + 600);
+      let x = blob.x - offset;
+      if (x < -blob.r) {
+        blob.x = width / pixelRatio + Math.random() * 600;
+        blob.y = Math.random() * (height / pixelRatio);
+        x = blob.x - offset;
+      }
+      ctx.beginPath();
+      ctx.fillStyle = baseColor;
+      ctx.globalAlpha = blob.alpha;
+      ctx.ellipse(x, blob.y, blob.r, blob.r * 0.75, Math.sin(blob.hueShift), 0, Math.PI * 2);
+      ctx.fill();
+    });
+    ctx.restore();
+  });
+}
+
+function drawWatercolorMist(progress) {
+  const { current, next, blend } = getBiome(progress);
+  const easing = easeInOut(blend);
+  ctx.save();
+  watercolorBrushes.forEach((brush, index) => {
+    brush.offset += brush.speed;
+    const x = (brush.x * width) / pixelRatio + Math.sin(brush.offset + index) * 90;
+    const y = (brush.y * height) / pixelRatio + Math.cos(brush.offset * 0.8) * 90;
+    const radius = brush.radius * (1 + Math.sin(brush.offset * 0.5) * 0.15);
+    const hueColor = lerpColor(
+      current.accents[index % current.accents.length],
+      next.accents[index % next.accents.length],
+      easing,
+      colorCache
+    );
+    const { r, g, b } = colorCache.get(hueColor);
+    const alpha = 0.04 + Math.sin(brush.offset) * 0.015;
+    ctx.fillStyle = `rgba(${r}, ${g}, ${b}, ${Math.max(alpha, 0.02)})`;
+    ctx.beginPath();
+    ctx.ellipse(x, y, radius, radius * 0.7, brush.offset, 0, Math.PI * 2);
+    ctx.fill();
+  });
+  ctx.restore();
+}
+
+function updateBike(delta) {
+  const desired = pedals.pressed ? settings.boostSpeed : settings.baseSpeed;
+  bike.targetSpeed = desired + (pedals.right ? 1.2 : 0) - (pedals.left ? 0.8 : 0);
+  bike.speed = lerp(bike.speed, bike.targetSpeed, 0.05);
+  bike.speed = Math.max(0.2, Math.min(bike.speed, 6));
+
+  const leanTarget = pedals.right ? 1 : pedals.left ? -1 : 0;
+  bike.lean = lerp(bike.lean, leanTarget, 0.03);
+  bike.wobble += delta * 0.003 + bike.speed * 0.001;
+  settings.worldScroll += bike.speed * 16 * delta;
+}
+
+function drawBike() {
+  const ground = bike.y();
+  const wobble = Math.sin(bike.wobble) * 3;
+  const bikeColor = "rgba(25, 35, 60, 0.9)";
+
+  ctx.save();
+  ctx.translate(bike.x, ground + wobble);
+  ctx.scale(1.1 + bike.speed * 0.02, 1.1 + bike.speed * 0.02);
+  ctx.rotate((bike.lean * Math.PI) / 32);
+
+  ctx.strokeStyle = bikeColor;
+  ctx.lineWidth = 4;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.beginPath();
+  ctx.ellipse(-40, 0, 36, 36, 0, 0, Math.PI * 2);
+  ctx.ellipse(40, 0, 36, 36, 0, 0, Math.PI * 2);
+  ctx.moveTo(-8, -20);
+  ctx.lineTo(0, -60);
+  ctx.lineTo(12, -20);
+  ctx.lineTo(-26, -12);
+  ctx.moveTo(-8, -20);
+  ctx.lineTo(38, -14);
+  ctx.moveTo(0, -60);
+  ctx.lineTo(0, -110);
+  ctx.stroke();
+
+  ctx.fillStyle = "rgba(25, 35, 60, 0.85)";
+  ctx.beginPath();
+  ctx.ellipse(0, -118, 26, 36, 0, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.restore();
+}
+
+function updateMemories(distance) {
+  memoryFragments.forEach((fragment) => {
+    if (fragment.collected) return;
+    if (distance > fragment.triggerAt - 40 && bike.speed < 1.5) {
+      fragment.collected = true;
+      const entry = document.createElement("div");
+      entry.className = "memory";
+      entry.innerHTML = `<strong>${fragment.biome}:</strong> ${fragment.text}`;
+      memoriesContainer.appendChild(entry);
+      memoriesContainer.scrollTop = memoriesContainer.scrollHeight;
+    }
+  });
+}
+
+function drawGround(progress) {
+  const { current, next, blend } = getBiome(progress);
+  const easing = easeInOut(blend);
+  const gradient = ctx.createLinearGradient(0, bike.y() - 20, 0, height / pixelRatio);
+  gradient.addColorStop(0, lerpColor(current.horizon[0], next.horizon[0], easing, colorCache));
+  gradient.addColorStop(1, "rgba(255,255,255,0)");
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, bike.y() - 20, width / pixelRatio, height / pixelRatio);
+
+  ctx.save();
+  ctx.translate(0, bike.y() + 12);
+  const baseY = 0;
+  ctx.strokeStyle = "rgba(25, 35, 60, 0.12)";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  for (let x = 0; x <= width / pixelRatio; x += 12) {
+    const noise = Math.sin((x + settings.worldScroll * 0.1) * 0.02) * 4;
+    ctx.lineTo(x, baseY + noise);
+  }
+  ctx.stroke();
+  ctx.restore();
+}
+
+function drawGlyphs(progress) {
+  const { current, next, blend } = getBiome(progress);
+  const easing = easeInOut(blend);
+  ctx.save();
+  ctx.globalAlpha = 0.3;
+  const accent = lerpColor(
+    current.accents[1 % current.accents.length],
+    next.accents[1 % next.accents.length],
+    easing,
+    colorCache
+  );
+  ctx.strokeStyle = accent;
+  ctx.lineWidth = 1.6;
+  ctx.setLineDash([6, 12]);
+  const distance = settings.worldScroll * 0.05;
+  for (let i = 0; i < 5; i += 1) {
+    const x = i * 240 - (distance % 240) + width / pixelRatio - 300;
+    ctx.beginPath();
+    ctx.moveTo(x, bike.y() - 120);
+    ctx.quadraticCurveTo(
+      x + 40 * Math.sin(distance * 0.1 + i),
+      bike.y() - 160,
+      x + 80,
+      bike.y() - 120
+    );
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+let lastTime = performance.now();
+
+function frame(time) {
+  const delta = Math.min(1, (time - lastTime) / 16.66);
+  lastTime = time;
+  settings.time += delta;
+
+  updateBike(delta);
+  const progress = settings.worldScroll / biomeLength;
+
+  renderWatercolorBackdrop(progress);
+  drawParallax(progress);
+  drawWatercolorMist(progress);
+  drawGround(progress);
+  drawGlyphs(progress);
+  drawBike();
+
+  updateMemories(settings.worldScroll);
+  ambientSound.update(bike.speed / settings.boostSpeed);
+
+  requestAnimationFrame(frame);
+}
+
+function seedMemories() {
+  for (let i = 1; i < 50; i += 1) {
+    const distance = i * (biomeLength / 2) + Math.random() * 400;
+    memoryFragments.push(createMemoryFragment(distance));
+  }
+}
+
+resize();
+seedMemories();
+requestAnimationFrame(frame);
+
+const introMemory = document.createElement("div");
+introMemory.className = "memory";
+introMemory.innerHTML =
+  "<strong>Departure:</strong> The road hums quietly, waiting for your first pedal.";
+memoriesContainer.appendChild(introMemory);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "ride-the-horizon",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ride-the-horizon",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ride-the-horizon",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,147 @@
+:root {
+  color-scheme: only light;
+  --text: #14213d;
+  --muted: rgba(20, 33, 61, 0.75);
+  --panel: rgba(255, 255, 255, 0.72);
+  --panel-blur: blur(12px);
+  --accent: #fca311;
+  font-size: clamp(16px, 2vw, 18px);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Manrope", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: #f4f1f5;
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  min-height: 100vh;
+  position: relative;
+}
+
+canvas {
+  width: 100%;
+  height: 100vh;
+  display: block;
+  background: #f1f1f1;
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;
+  padding: clamp(1rem, 5vw, 3rem);
+}
+
+.overlay__header,
+.overlay__footer {
+  background: var(--panel);
+  backdrop-filter: var(--panel-blur);
+  border-radius: 16px;
+  padding: 1.25rem;
+  max-width: 420px;
+  box-shadow: 0 20px 45px rgba(20, 33, 61, 0.1);
+  pointer-events: auto;
+}
+
+.overlay__header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.overlay__header p {
+  margin: 0;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.overlay__memories {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 30vh;
+  overflow-y: auto;
+  padding: 1.5rem 0;
+  pointer-events: none;
+}
+
+.memory {
+  align-self: flex-start;
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 14px;
+  padding: 0.85rem 1.1rem;
+  box-shadow: 0 10px 30px rgba(31, 41, 55, 0.15);
+  color: var(--muted);
+  max-width: min(400px, 70vw);
+  font-size: 0.95rem;
+  animation: memory-fade-in 12s ease-in-out forwards;
+}
+
+.memory strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+@keyframes memory-fade-in {
+  0% {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  10% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0.1;
+    transform: translateY(-12px);
+  }
+}
+
+button {
+  font: inherit;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.65rem 1.5rem;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(252, 163, 17, 0.28);
+}
+
+button:focus-visible {
+  outline: 3px solid rgba(252, 163, 17, 0.48);
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px) {
+  .overlay {
+    padding: clamp(1rem, 8vw, 2rem);
+  }
+
+  .overlay__header,
+  .overlay__footer {
+    max-width: none;
+  }
+
+  .memory {
+    max-width: 100%;
+  }
+}

--- a/tests/game-core.test.js
+++ b/tests/game-core.test.js
@@ -1,0 +1,112 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  biomes,
+  memoryLibrary,
+  biomeLength,
+  lerp,
+  easeInOut,
+  normaliseProgress,
+  getBiome,
+  parseHexColor,
+  parseRgbColor,
+  parseColor,
+  gradientColor,
+  lerpColor,
+  ColorCache,
+  createMemoryFragment,
+} from '../js/game-core.js';
+
+describe('math helpers', () => {
+  test('lerp interpolates linearly', () => {
+    assert.equal(lerp(0, 10, 0.25), 2.5);
+  });
+
+  test('easeInOut clamps to range', () => {
+    assert.equal(easeInOut(-1), 0);
+    assert.equal(easeInOut(0), 0);
+    assert.equal(easeInOut(1), 1);
+    assert.equal(easeInOut(2), 1);
+  });
+
+  test('normaliseProgress wraps negative values', () => {
+    const { index, blend } = normaliseProgress(-0.25, 4);
+    assert.equal(index, 3);
+    assert.equal(Number(blend.toFixed(2)), 0.75);
+  });
+});
+
+describe('biome traversal', () => {
+  test('getBiome cycles through list', () => {
+    const { current, next, blend } = getBiome(2.4);
+    assert.equal(current.name, biomes[2].name);
+    assert.equal(next.name, biomes[3].name);
+    assert.equal(Number(blend.toFixed(2)), 0.4);
+  });
+
+  test('getBiome handles large progress values', () => {
+    const { current, next } = getBiome(14.1);
+    const expectedIndex = Math.floor(((14.1 % biomes.length) + biomes.length) % biomes.length);
+    assert.equal(current.name, biomes[expectedIndex].name);
+    assert.equal(next.name, biomes[(expectedIndex + 1) % biomes.length].name);
+  });
+});
+
+describe('color utilities', () => {
+  const cache = new ColorCache();
+
+  test('parseHexColor supports shorthand', () => {
+    assert.deepEqual(parseHexColor('#0f8'), { r: 0, g: 255, b: 136 });
+  });
+
+  test('parseRgbColor extracts components', () => {
+    assert.deepEqual(parseRgbColor('rgb(10, 20, 30)'), { r: 10, g: 20, b: 30 });
+  });
+
+  test('parseColor rejects empty strings', () => {
+    assert.throws(() => parseColor(''), { name: 'TypeError' });
+  });
+
+  test('gradientColor interpolates between values', () => {
+    const colour = gradientColor(['#000000', '#ffffff'], 0.5, cache);
+    assert.equal(colour, 'rgb(128, 128, 128)');
+  });
+
+  test('gradientColor clamps out-of-range t', () => {
+    const colour = gradientColor(['#123456', '#abcdef'], 9, cache);
+    assert.equal(colour, 'rgb(171, 205, 239)');
+  });
+
+  test('lerpColor blends using cache', () => {
+    const colour = lerpColor('#000000', '#ffffff', 0.25, cache);
+    assert.equal(colour, 'rgb(64, 64, 64)');
+  });
+});
+
+describe('memory fragments', () => {
+  test('createMemoryFragment picks biome and text deterministically', () => {
+    const sequence = [0.1, 0.9, 0.3];
+    let pointer = 0;
+    const rng = () => {
+      const value = sequence[pointer % sequence.length];
+      pointer += 1;
+      return value;
+    };
+    const distance = biomeLength * 1.5; // second biome when wrapping
+    const fragment = createMemoryFragment(distance, {
+      rng,
+      library: memoryLibrary,
+      biomeList: biomes,
+      length: biomeLength,
+    });
+    assert.equal(fragment.biome, biomes[1].name);
+    assert.equal(fragment.text, memoryLibrary[Math.floor(sequence[0] * memoryLibrary.length)]);
+    assert.equal(fragment.collected, false);
+    assert.equal(fragment.triggerAt, distance);
+    assert.match(fragment.id, new RegExp(`^${distance}-[0-9a-f]+$`));
+  });
+
+  test('createMemoryFragment validates input', () => {
+    assert.throws(() => createMemoryFragment(Number.NaN), { name: 'TypeError' });
+  });
+});


### PR DESCRIPTION
## Summary
- extract reusable biome, color, and memory helpers into a dedicated game-core module with validation and caching safeguards
- refactor the canvas runtime to consume the shared utilities, improve resize handling, and harden ambient audio startup
- add a Node-based unit test suite and document the npm test workflow for local verification

## Testing
- npm test
- npm audit

------
https://chatgpt.com/codex/tasks/task_e_68e154bb0fe08325886954dfc140ba32